### PR TITLE
dev-samerde-build-fixes-01

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -25,6 +25,7 @@ Build-Module -ModuleName 'BlueTuxedo' {
         Copyright            = "(c) 2023 - $((Get-Date).Year). All rights reserved."
         Description          = 'A tiny tool to identify and remediate common misconfigurations in Active Directory-Integrated DNS.'
         PowerShellVersion    = '5.1'
+        ProjectUri           = 'https://github.com/TrimarcJake/BlueTuxedo'
         Tags                 = @('Windows', 'BlueTuxedo', 'DNS', 'AD', 'ActiveDirectory', 'DomainNameSystem','ADIDNS')
     }
     New-ConfigurationManifest @Manifest

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -45,8 +45,7 @@ Build-Module -ModuleName 'BlueTuxedo' {
         # those modules are builtin in PowerShell so no need to install them
         # could as well be ignored with New-ConfigurationModuleSkip
         'Microsoft.PowerShell.Utility'
-        'Microsoft.PowerShell.LocalAccounts',
-        'Microsoft.PowerShell.Utility'
+        'Microsoft.PowerShell.LocalAccounts'
         'Microsoft.PowerShell.Management'
     )
     foreach ($Module in $ExternalModules) {

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -110,6 +110,6 @@ Build-Module -ModuleName 'BlueTuxedo' {
     New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Artefacts\Script" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
     New-ConfigurationArtefact -Type ScriptPacked -Enable -Path "$PSScriptRoot\..\Artefacts\ScriptPacked" -ArtefactName "Invoke-<ModuleName>.zip" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked"
-
-    # Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-BlueTuxedo.ps1" "$PSScriptRoot\..\"
 }
+
+# Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-BlueTuxedo.ps1" "$PSScriptRoot\..\"

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -102,12 +102,9 @@ Build-Module -ModuleName 'BlueTuxedo' {
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -UseWildcardForFunctions
 
     $PreScriptMerge = {
-        param (
-            [int]$Mode
-        )
     }
 
-    $PostScriptMerge = { Invoke-BlueTuxedo -Mode $Mode }
+    $PostScriptMerge = { Invoke-BlueTuxedo }
 
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -ArtefactName '<ModuleName>.zip'
     New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Artefacts\Script" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"


### PR DESCRIPTION
I noticed a few issues that were carried over from the Locksmith project's build script. Cleaned those up and added the ProjectUri attribute so visitors to the PowerShell Gallery can link back to the GitHub repository, making it easier for them to contribute or review the code before running.