### PR TITLE
Added an option to export raw collected and tested data

### DIFF
--- a/Private/Utility/Export-Results.ps1
+++ b/Private/Utility/Export-Results.ps1
@@ -1,0 +1,30 @@
+function Export-Results {
+    <#
+    .SYNOPSIS
+    Export the results to text files.
+
+    .DESCRIPTION
+    Export the results to text files.
+
+    .PARAMETER Name
+    Name of the file.
+
+    .PARAMETER Data
+    Data that will be exported to a file.
+
+    .PARAMETER FilePath
+    Path in which the file will be created.
+
+    .EXAMPLE
+    Export-Results -Name "Tested $item" -Data $TestedData.$Item
+
+    #>
+    [Cmdletbinding()]
+    param (
+        [string]$Name,
+        $Data,
+        [string]$FilePath = (Join-Path -Path $pwd -ChildPath "BlueTuxedo $Name $(Get-Date -f 'yyyyMMddhhmmss').txt")
+    )
+
+    Out-File -FilePath $FilePath -Encoding utf8 -InputObject $Data
+}

--- a/Public/Invoke-BlueTuxedo.ps1
+++ b/Public/Invoke-BlueTuxedo.ps1
@@ -6,73 +6,97 @@ function Invoke-BlueTuxedo {
         [switch]$ShowSecurityDescriptors = $false,
         [switch]$Demo = $false
     )
+
     if ($Demo) { Clear-Host }
+    Show-BTLogo -Version 'v2024.2-testing'
+
     $Domains = Get-BTTarget -Forest $Forest -InputPath $InputPath
 
-    Show-BTLogo -Version "v2024.2-testing"
-
-    # Get Data
+    #region Get Data
     Write-Host 'Please hold. Collecting DNS data from the following domains:' -ForegroundColor Green
     Write-Host $Domains -ForegroundColor Yellow
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Zones"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Zones" -Verbose
     $ADIZones = Get-BTADIZone -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Conditional Forwarders"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Conditional Forwarders" -Verbose
     $ConditionalForwarders = Get-BTConditionalForwarder -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dangling SPNs"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dangling SPNs" -Verbose
     $DanglingSPNs = Get-BTDanglingSPN -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] DNS Admins Memberships"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] DNS Admins Memberships" -Verbose
     $DnsAdminsMemberships = Get-BTDnsAdminsMembership -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] DNS Update Proxy Memberships"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] DNS Update Proxy Memberships" -Verbose
     $DnsUpdateProxyMemberships = Get-BTDnsUpdateProxyMembership -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts" -Verbose
     $DynamicUpdateServiceAccounts = Get-BTDynamicUpdateServiceAccount -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configuration"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configuration" -Verbose
     $ForwarderConfigurations = Get-BTForwarderConfiguration -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Global Query Blocklists"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Global Query Blocklists" -Verbose
     $GlobalQueryBlockLists = Get-BTGlobalQueryBlockList -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Non ADI Zones"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Name Protection Configuration Lists" -Verbose
+    $NameProtectionConfigurationLists = Get-BTNameProtectionConfiguration -Domains $Domains
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Non ADI Zones" -Verbose
     $NonADIZones = Get-BTNonADIZone -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Query Resolution Policies"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Query Resolution Policies" -Verbose
     $QueryResolutionPolicys = Get-BTQueryResolutionPolicy -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors" -Verbose
     $SecurityDescriptors = Get-BTSecurityDescriptor -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes" -Verbose
     $SocketPoolSizes = Get-BTSocketPoolSize -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Tombstoned Nodes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Tombstoned Nodes" -Verbose
     $TombstonedNodes = Get-BTTombstonedNode -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records" -Verbose
     $WildcardRecords = Get-BTWildcardRecord -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] WPAD Records" -Verbose
     $WPADRecords = Get-BTWPADRecord -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scopes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scopes" -Verbose
     $ZoneScopes = Get-BTZoneScope -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers" -Verbose
     $ZoneScopeContainers = Get-BTZoneScopeContainer -ADIZones $ADIZones
+
     Write-Host 'Finished collecting DNS data from the following domains:' -ForegroundColor Green
     Write-Host $Domains -ForegroundColor Yellow
 
     $CollectedData = @{
-        'ADIZones' = $ADIZones
-        'ConditionalForwarders' = $ConditionalForwarders
-        'DanglingSPNs' = $DanglingSPNs
-        'DnsAdminsMemberships' = $DnsAdminsMemberships
-        'DnsUpdateProxyMemberships' = $DnsUpdateProxyMemberships
+        'ADIZones'                     = $ADIZones
+        'ConditionalForwarders'        = $ConditionalForwarders
+        'DanglingSPNs'                 = $DanglingSPNs
+        'DnsAdminsMemberships'         = $DnsAdminsMemberships
+        'DnsUpdateProxyMemberships'    = $DnsUpdateProxyMemberships
         'DynamicUpdateServiceAccounts' = $DynamicUpdateServiceAccounts
-        'ForwarderConfigurations' = $ForwarderConfigurations
-        'GlobalQueryBlockLists' = $GlobalQueryBlockLists
-        'NonADIZones' = $NonADIZones
-        'QueryResolutionPolicys' = $QueryResolutionPolicys
-        'SecurityDescriptors' = $SecurityDescriptors
-        'SocketPoolSizes' = $SocketPoolSizes
-        'TombstonedNodes' = $TombstonedNodes
-        'WildcardRecords' = $WildcardRecords
-        'WPADRecords' = $WPADRecords
-        'ZoneScopes' = $ZoneScopes
-        'ZoneScopeContainers' = $ZoneScopeContainers
+        'ForwarderConfigurations'      = $ForwarderConfigurations
+        'GlobalQueryBlockLists'        = $GlobalQueryBlockLists
+        #'NameProtectionLists'         = $NameProtectionConfigurationLists
+        'NonADIZones'                  = $NonADIZones
+        'QueryResolutionPolicys'       = $QueryResolutionPolicys
+        'SecurityDescriptors'          = $SecurityDescriptors
+        'SocketPoolSizes'              = $SocketPoolSizes
+        'TombstonedNodes'              = $TombstonedNodes
+        'WildcardRecords'              = $WildcardRecords
+        'WPADRecords'                  = $WPADRecords
+        'ZoneScopes'                   = $ZoneScopes
+        'ZoneScopeContainers'          = $ZoneScopeContainers
     }
+    #endregion Get Data
 
     # Display All Collected Data
-    $show = Read-Host "Show all collected DNS data? [Y]/n"
+    $show = Read-Host 'Show all collected DNS data? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
             Show-BTCollectedData -Demo @CollectedData
@@ -88,57 +112,57 @@ function Invoke-BlueTuxedo {
     # Test Data
     if ($Demo) { Clear-Host }
     Write-Host 'Currently testing collected DNS data to identify possible issues...' -ForegroundColor Green
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Legacy Zones"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Legacy Zones"
     $TestedADILegacyZones = Test-BTADILegacyZone -ADIZones $ADIZones
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Insecure Update Zones"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Insecure Update Zones"
     $TestedADIInsecureUpdateZones = Test-BTADIInsecureUpdateZone -ADIZones $ADIZones
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
     $TestedDynamicUpdateServiceAccounts = Test-BTDynamicUpdateServiceAccount -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configurations"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configurations"
     $TestedForwarderConfigurations = Test-BTForwarderConfiguration -ForwarderConfigurations $ForwarderConfigurations
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Global Query Block Lists"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Global Query Block Lists"
     $TestedGlobalQueryBlockLists = Test-BTGlobalQueryBlockList -GlobalQueryBlockLists $GlobalQueryBlockLists
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor ACE"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor ACE"
     $TestedSecurityDescriptorACEs = Test-BTSecurityDescriptorACE -SecurityDescriptors $SecurityDescriptors -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor Owner"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor Owner"
     $TestedSecurityDescriptorOwners = Test-BTSecurityDescriptorOwner -SecurityDescriptors $SecurityDescriptors -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
-    $TestedSocketPoolSizes = Test-BTSocketPoolSize -SocketPoolSizes $SocketPoolSizes 
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
+    $TestedSocketPoolSizes = Test-BTSocketPoolSize -SocketPoolSizes $SocketPoolSizes
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
     $TestedWildcardRecords = Test-BTWildcardRecord -WildcardRecords $WildcardRecords
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
     $TestedWPADRecords = Test-BTWPADRecord -WPADRecords $WPADRecords
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
     $TestedZoneScopeContainers = Test-BTZoneScopeContainer -ZoneScopeContainers $ZoneScopeContainers
     Write-Host 'Finished testing collected DNS data to identify possible issues.`n' -ForegroundColor Green
 
     $TestedData = @{
-        'ConditionalForwarders' = $ConditionalForwarders
-        'DanglingSPNs' = $DanglingSPNs
-        'DnsAdminsMemberships' = $DnsAdminsMemberships
-        'DnsUpdateProxyMemberships' = $DnsUpdateProxyMemberships
-        'NonADIZones' = $NonADIZones
-        'QueryResolutionPolicys' = $QueryResolutionPolicys
-        'TombstonedNodes' = $TombstonedNodes
-        'ZoneScopes' = $ZoneScopes
-        'TestedADILegacyZones' = $TestedADILegacyZones
-        'TestedADIInsecureUpdateZones' = $TestedADIInsecureUpdateZones
+        'ConditionalForwarders'              = $ConditionalForwarders
+        'DanglingSPNs'                       = $DanglingSPNs
+        'DnsAdminsMemberships'               = $DnsAdminsMemberships
+        'DnsUpdateProxyMemberships'          = $DnsUpdateProxyMemberships
+        'NonADIZones'                        = $NonADIZones
+        'QueryResolutionPolicys'             = $QueryResolutionPolicys
+        'TombstonedNodes'                    = $TombstonedNodes
+        'ZoneScopes'                         = $ZoneScopes
+        'TestedADILegacyZones'               = $TestedADILegacyZones
+        'TestedADIInsecureUpdateZones'       = $TestedADIInsecureUpdateZones
         'TestedDynamicUpdateServiceAccounts' = $TestedDynamicUpdateServiceAccounts
-        'TestedForwarderConfigurations' = $TestedForwarderConfigurations
-        'TestedGlobalQueryBlockLists' = $TestedGlobalQueryBlockLists
-        'TestedSecurityDescriptorACEs' = $TestedSecurityDescriptorACEs
-        'TestedSecurityDescriptorOwners' = $TestedSecurityDescriptorOwners
-        'TestedSocketPoolSizes' = $TestedSocketPoolSizes
-        'TestedWildcardRecords' = $TestedWildcardRecords
-        'TestedWPADRecords' = $TestedWPADRecords
-        'TestedZoneScopeContainers' = $TestedZoneScopeContainers
+        'TestedForwarderConfigurations'      = $TestedForwarderConfigurations
+        'TestedGlobalQueryBlockLists'        = $TestedGlobalQueryBlockLists
+        'TestedSecurityDescriptorACEs'       = $TestedSecurityDescriptorACEs
+        'TestedSecurityDescriptorOwners'     = $TestedSecurityDescriptorOwners
+        'TestedSocketPoolSizes'              = $TestedSocketPoolSizes
+        'TestedWildcardRecords'              = $TestedWildcardRecords
+        'TestedWPADRecords'                  = $TestedWPADRecords
+        'TestedZoneScopeContainers'          = $TestedZoneScopeContainers
     }
-    
+
     # Display All Tested Data
-    $show = Read-Host "Show possible DNS issues in the environment? [Y]/n"
+    $show = Read-Host 'Show possible DNS issues in the environment? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
-            Show-BTTestedData -Demo  @TestedData
+            Show-BTTestedData -Demo @TestedData
         } elseif ($ShowSecurityDescriptors) {
             Show-BTTestedData -ShowSecurityDescriptors @TestedData
         } elseif ($Demo -and $ShowSecurityDescriptors) {
@@ -149,7 +173,7 @@ function Invoke-BlueTuxedo {
     }
 
     # Display Fixes
-    $show = Read-Host "Show fixes for identified issues? [Y]/n"
+    $show = Read-Host 'Show fixes for identified issues? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
             Show-BTFixes -Demo @TestedData


### PR DESCRIPTION
Added `-ExportCollectedData` and `-ExportTestedData` to `Invoke-BlueTuxedo` to save manual extraction. These two parameters and the new `Export-Results` function creates a separate text file for each BT test.