### PR TITLE
Add ability to exclude a DNS server from checks

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-﻿if (Get-Module -Name 'PSPublishModule' -ListAvailable) { 
+﻿if (Get-Module -Name 'PSPublishModule' -ListAvailable) {
     Write-Information 'PSPublishModule is installed.'
 } else {
     Write-Information 'PSPublishModule is not installed. Attempting installation.'
@@ -6,8 +6,7 @@
         Install-Module -Name Pester -AllowClobber -Scope CurrentUser -SkipPublisherCheck -Force
         Install-Module -Name PSScriptAnalyzer -Scope CurrentUser -Force
         Install-Module -Name PSPublishModule -AllowClobber -Scope CurrentUser -Force
-    }
-    catch {
+    } catch {
         Write-Error 'PSPublishModule installation failed.'
     }
 }
@@ -26,7 +25,7 @@ Build-Module -ModuleName 'BlueTuxedo' {
         Description          = 'A tiny tool to identify and remediate common misconfigurations in Active Directory-Integrated DNS.'
         PowerShellVersion    = '5.1'
         ProjectUri           = 'https://github.com/TrimarcJake/BlueTuxedo'
-        Tags                 = @('Windows', 'BlueTuxedo', 'DNS', 'AD', 'ActiveDirectory', 'DomainNameSystem','ADIDNS')
+        Tags                 = @('Windows', 'BlueTuxedo', 'DNS', 'AD', 'ActiveDirectory', 'DomainNameSystem', 'ADIDNS')
     }
     New-ConfigurationManifest @Manifest
 
@@ -102,14 +101,27 @@ Build-Module -ModuleName 'BlueTuxedo' {
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -UseWildcardForFunctions
 
     $PreScriptMerge = {
+        param (
+            # DNS server(s) to exclude from checks.
+            [string[]]$Exclude
+        )
+
     }
 
-    $PostScriptMerge = { Invoke-BlueTuxedo }
+    $PostScriptMerge = {
+
+        if ($Exclude) {
+            $BTData = Invoke-BlueTuxedo -Exclude $Exclude -ExportCollectedData -ExportTestedData
+        } else {
+            $BTData = Invoke-BlueTuxedo -ExportCollectedData -ExportTestedData
+        }
+        $BTData
+    }
 
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -ArtefactName '<ModuleName>.zip'
-    New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Artefacts\Script" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
-    New-ConfigurationArtefact -Type ScriptPacked -Enable -Path "$PSScriptRoot\..\Artefacts\ScriptPacked" -ArtefactName "Invoke-<ModuleName>.zip" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName "Invoke-<ModuleName>.ps1"
+    New-ConfigurationArtefact -Type Script -Enable -Path "$PSScriptRoot\..\Artefacts\Script" -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName 'Invoke-<ModuleName>.ps1'
+    New-ConfigurationArtefact -Type ScriptPacked -Enable -Path "$PSScriptRoot\..\Artefacts\ScriptPacked" -ArtefactName 'Invoke-<ModuleName>.zip' -PreScriptMerge $PreScriptMerge -PostScriptMerge $PostScriptMerge -ScriptName 'Invoke-<ModuleName>.ps1'
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked"
 }
 
-# Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-BlueTuxedo.ps1" "$PSScriptRoot\..\"
+Copy-Item "$PSScriptRoot\..\Artefacts\Script\Invoke-BlueTuxedo.ps1" "$PSScriptRoot\..\"

--- a/Private/Get/Get-BTConditionalForwarder.ps1
+++ b/Private/Get/Get-BTConditionalForwarder.ps1
@@ -2,33 +2,48 @@ function Get-BTConditionalForwarder {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
+
     $ZoneList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            $Zones = Get-DnsServerZone -ComputerName $dnsServer.IP4Address | Where-Object { 
-                ($_.IsAutoCreated -eq $false) -and 
-                ($_.ZoneType -eq 'Forwarder') -and
-                ($_.IsDsIntegrated -eq $true)
+
+    foreach ($dnsServer in $script:DNSServers) {
+
+        # Enumerate the zones on each DNS server
+        $Zones = Get-DnsServerZone -ComputerName $dnsServer.IPAddress | Where-Object {
+            ( $_.IsAutoCreated -eq $false ) -and
+            ( $_.ZoneType -eq 'Forwarder' ) -and
+            ( $_.IsDsIntegrated -eq $true )
+        }
+
+        # Loop through each zone on the server
+        foreach ($zone in $Zones) {
+            $AddToList = [PSCustomObject]@{
+                'Domain'    = $domain
+                'Zone Name' = $zone.ZoneName
             }
-            
-            foreach ($zone in $Zones) {
-                $AddToList = [PSCustomObject]@{
-                    'Domain' = $domain
-                    'Zone Name'   = $zone.ZoneName
-                }
-                
-                $ZoneList += $AddToList
-            }
+
+            # Add the info to the ZoneList array
+            $ZoneList += $AddToList
         }
     }
 
+    if ($ZoneList.Count -lt 1) {
+        Write-Host 'No conditional forward lookup zones were found.'
+    }
+    # Return the ZoneList object
     $ZoneList
 }

--- a/Private/Get/Get-BTDnsServers.ps1
+++ b/Private/Get/Get-BTDnsServers.ps1
@@ -1,0 +1,47 @@
+function Get-BTDnsServers {
+    [CmdletBinding()]
+    param (
+        # Domains to inspect
+        [Parameter()]
+        [array]$Domains,
+
+        # Name server to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
+    )
+
+    if ($null -eq $Domains) {
+        $Domains = Get-BTTarget
+    }
+
+    if ($PSBoundParameters.Keys.Contains('Exclude')) {
+        # Exclude certain name server[s]
+        [string[]]$ExcludeList = @()
+        foreach ($item in $Exclude) {
+            foreach ($domain in $Domains) {
+                # Normalize the server name to an FQDN
+                if ($item -match "$($domain)$") {
+                    $ExcludeList += $item
+                } else {
+                    $ExcludeList += "$item.${domain}"
+                }
+                # This could more precisely get the proper FQDN but works for now
+            }
+        }
+        Write-Verbose "Excluding: $($ExcludeList -join ',')"
+    }
+
+    $DnsServerList = @()
+
+    # Loop through each domain
+    foreach ($domain in $Domains) {
+
+        # Find and loop through each DNS server
+        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object { $ExcludeList -notin $_.Name } | Where-Object { $_.QueryType -eq 'A' } | Sort-Object Name
+        $DnsServerList += $DNSServers
+    }
+
+    Write-Verbose "Found $($DNSServers.Count) DNS servers in $($Domains.Count) domains."
+    $DnsServerList
+}

--- a/Private/Get/Get-BTForwarderConfiguration.ps1
+++ b/Private/Get/Get-BTForwarderConfiguration.ps1
@@ -2,31 +2,46 @@ function Get-BTForwarderConfiguration {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
-    $ForwarderList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            [array]$Forwarders = Get-DnsServerForwarder -ComputerName $dnsServer.IP4Address
-            if ($ForwarderList.'Server IP' -notcontains $dnsServer.IP4Address) {
-                foreach ($forwarder in $Forwarders) {
-                    $AddToList = [PSCustomObject]@{
-                        'Server Name'   = $dnsServer.Name
-                        'Server IP'     = $dnsServer.IP4Address
-                        'Forwarders'    = $forwarder.IPAddress.IPAddressToString
-                    }
-                }
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
 
-                $ForwarderList += $AddToList
+    $ForwarderList = @()
+
+    foreach ($dnsServer in $script:DNSServers) {
+
+        # Enumerate the forwarders on each DNS server
+        [array]$Forwarders = Get-DnsServerForwarder -ComputerName $dnsServer.IPAddress
+
+        # Add to the list if this DNS server's IP address is not already in the list.
+        if ($ForwarderList.'Server IP' -notcontains $dnsServer.IPAddress) {
+            foreach ($forwarder in $Forwarders) {
+                $AddToList = [PSCustomObject]@{
+                    'Server Name' = $dnsServer.Name
+                    'Server IP'   = $dnsServer.IPAddress
+                    'Forwarders'  = $forwarder.IPAddress.IPAddressToString
+                }
             }
+
+            $ForwarderList += $AddToList
         }
     }
 
+    if ($ForwarderList.Count -lt 1) {
+        Write-Host 'No forwarders were found.'
+    }
+    # Return the ForwarderList object
     $ForwarderList
 }

--- a/Private/Get/Get-BTNonADIZone.ps1
+++ b/Private/Get/Get-BTNonADIZone.ps1
@@ -2,36 +2,50 @@ function Get-BTNonADIZone {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
+
     $ZoneList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            $Zones = Get-DnsServerZone -ComputerName $dnsServer.IP4Address | Where-Object { 
-                ($_.IsAutoCreated -eq $false) -and 
-                ($_.ZoneType -ne 'Forwarder') -and
-                ($_.IsDsIntegrated -eq $false)
+
+    foreach ($dnsServer in $script:DNSServers) {
+
+        # Enumerate the zones on each DNS server.
+        $Zones = Get-DnsServerZone -ComputerName $dnsServer.IPAddress | Where-Object {
+            ($_.IsAutoCreated -eq $false) -and
+            ($_.ZoneType -ne 'Forwarder') -and
+            ($_.IsDsIntegrated -eq $false)
+        }
+
+        # Add zone and server details to the zone list.
+        foreach ($zone in $Zones) {
+            $AddToList = [PSCustomObject]@{
+                'Server Name' = $dnsServer.Name
+                'Server IP'   = $dnsServer.IPAddress
+                'Zone Name'   = $zone.ZoneName
+                'Zone Type'   = $zone.ZoneType
+                'Is Reverse?' = $zone.IsReverseLookupZone
             }
-            
-            foreach ($zone in $Zones) {
-                $AddToList = [PSCustomObject]@{
-                    'Server Name' = $dnsServer.Name
-                    'Server IP'   = $dnsServer.IP4Address
-                    'Zone Name'   = $zone.ZoneName
-                    'Zone Type'   = $zone.ZoneType
-                    'Is Reverse?' = $zone.IsReverseLookupZone
-                }
-                
-                $ZoneList += $AddToList
-            }
+
+            $ZoneList += $AddToList
         }
     }
 
+    if ($ZoneList.Count -lt 1) {
+        Write-Host 'No non-AD-integrated zones were found.'
+    }
+    # Return the ZoneList object
     $ZoneList
 }

--- a/Private/Get/Get-BTQueryResolutionPolicy.ps1
+++ b/Private/Get/Get-BTQueryResolutionPolicy.ps1
@@ -2,35 +2,46 @@ function Get-BTQueryResolutionPolicy {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
+
     $QueryResolutionPolicyList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            $QueryResolutionPolicies = (Get-DnsServer -ComputerName $dnsServer.IP4Address -ErrorAction Ignore -WarningAction Ignore).ServerPolicies
-            if ($QueryResolutionPolicyList.'Server IP' -notcontains $dnsServer.IP4Address) {
-                    foreach ($policy in $QueryResolutionPolicies) {
-                        $AddToList = [PSCustomObject]@{
-                        'Server Name'          = $dnsServer.Name
-                        'Server IP'            = $dnsServer.IP4Address
-                        'QRP Name'             = $policy.Name
-                        'QRP Level'            = $policy.Level
-                        'QRP Processing Order' = $policy.ProcessingOrder
-                        'QRP Enabled?'         = $policy.IsEnabled
-                        'QRP Action'           = $policy.Action
-                    }
 
-                    $QueryResolutionPolicyList += $AddToList
+    foreach ($dnsServer in $script:DNSServers) {
+
+        # Enumerate the query resolution policies on each DNS server
+        $QueryResolutionPolicies = (Get-DnsServer -ComputerName $dnsServer.IPAddress -ErrorAction Ignore -WarningAction Ignore).ServerPolicies
+
+        # Add to the list if this DNS server's IP address is not already in the list.
+        if ($QueryResolutionPolicyList.'Server IP' -notcontains $dnsServer.IPAddress) {
+            foreach ($policy in $QueryResolutionPolicies) {
+                $AddToList = [PSCustomObject]@{
+                    'Server Name'          = $dnsServer.Name
+                    'Server IP'            = $dnsServer.IPAddress
+                    'QRP Name'             = $policy.Name
+                    'QRP Level'            = $policy.Level
+                    'QRP Processing Order' = $policy.ProcessingOrder
+                    'QRP Enabled?'         = $policy.IsEnabled
+                    'QRP Action'           = $policy.Action
                 }
-            }
 
+                $QueryResolutionPolicyList += $AddToList
+            }
         }
+
     }
 
     $QueryResolutionPolicyList

--- a/Private/Get/Get-BTSocketPoolSize.ps1
+++ b/Private/Get/Get-BTSocketPoolSize.ps1
@@ -2,28 +2,37 @@ function Get-BTSocketPoolSize {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
-    $SocketPoolSizeList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            [int32]$SocketPoolSize = (Get-DnsServerSetting -ComputerName $dnsServer.IP4Address -All -WarningAction Ignore).SocketPoolSize
-            if ($SocketPoolSizeList.'Server IP' -notcontains $dnsServer.IP4Address) {
-                $AddToList = [PSCustomObject]@{
-                    'Server Name'         = $dnsServer.Name
-                    'Server IP'           = $dnsServer.IP4Address
-                    'Socket Pool Size'    = $SocketPoolSize
-                }
-            }
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
 
-            $SocketPoolSizeList += $AddToList
+    $SocketPoolSizeList = @()
+
+    foreach ($dnsServer in $script:DNSServers) {
+
+        # Enumerate the socket pool size on each DNS server.
+        [int32]$SocketPoolSize = (Get-DnsServerSetting -ComputerName $dnsServer.IPAddress -All -WarningAction Ignore).SocketPoolSize
+        if ($SocketPoolSizeList.'Server IP' -notcontains $dnsServer.IPAddress) {
+            $AddToList = [PSCustomObject]@{
+                'Server Name'      = $dnsServer.Name
+                'Server IP'        = $dnsServer.IPAddress
+                'Socket Pool Size' = $SocketPoolSize
+            }
         }
+
+        $SocketPoolSizeList += $AddToList
     }
 
     $SocketPoolSizeList

--- a/Private/Get/Get-BTZoneScope.ps1
+++ b/Private/Get/Get-BTZoneScope.ps1
@@ -2,36 +2,45 @@ function Get-BTZoneScope {
     [CmdletBinding()]
     param (
         [Parameter()]
-        [array]$Domains
+        [array]$Domains,
+
+        # Name of the DNS server[s] to exclude
+        [Parameter()]
+        [string[]]
+        $Exclude
     )
 
     if ($null -eq $Domains) {
         $Domains = Get-BTTarget
     }
 
+    if ($null -eq $script:DNSServers) {
+        $script:DNSServers = Get-BTDnsServers -Domains $Domains -Exclude $Exclude
+    }
+
     $ZoneScopeList = @()
-    foreach ($domain in $Domains) {
-        $DNSServers = Resolve-DnsName -Type NS -Name $domain | Where-Object QueryType -eq 'A'
-        foreach ($dnsServer in $DNSServers) {
-            $ZoneScopes = Get-DnsServerZone -ComputerName $dnsServer.IP4Address | Where-Object { 
-                ($_.IsDsIntegrated -eq $true) -and
-                ($_.IsReverseLookupZone -eq $false) -and
-                ($_.ZoneName -ne 'TrustAnchors')
-            } | Get-DnsServerZoneScope -ComputerName $dnsServer.IP4Address -ErrorAction Ignore
 
-            if ($ZoneScopeList.'Server IP' -notcontains $dnsServer.IP4Address) {
-                    foreach ($scope in $ZoneScopes) {
-                        $AddToList = [PSCustomObject]@{
-                        'Server Name'     = $dnsServer.Name
-                        'Server IP'       = $dnsServer.IP4Address
-                        'Zone Scope Name' = $scope.ZoneScope
-                    }
+    foreach ($dnsServer in $script:DNSServers) {
 
-                    $ZoneScopeList += $AddToList
+        # Enumerate the zone scopes on each DNS server
+        $ZoneScopes = Get-DnsServerZone -ComputerName $dnsServer.IPAddress | Where-Object {
+            ($_.IsDsIntegrated -eq $true) -and
+            ($_.IsReverseLookupZone -eq $false) -and
+            ($_.ZoneName -ne 'TrustAnchors')
+        } | Get-DnsServerZoneScope -ComputerName $dnsServer.IPAddress -ErrorAction Ignore
+
+        if ($ZoneScopeList.'Server IP' -notcontains $dnsServer.IPAddress) {
+            foreach ($scope in $ZoneScopes) {
+                $AddToList = [PSCustomObject]@{
+                    'Server Name'     = $dnsServer.Name
+                    'Server IP'       = $dnsServer.IPAddress
+                    'Zone Scope Name' = $scope.ZoneScope
                 }
-            }
 
+                $ZoneScopeList += $AddToList
+            }
         }
+
     }
 
     $ZoneScopeList

--- a/Private/Utility/Export-Results.ps1
+++ b/Private/Utility/Export-Results.ps1
@@ -1,0 +1,30 @@
+function Export-Results {
+    <#
+    .SYNOPSIS
+    Export the results to text files.
+
+    .DESCRIPTION
+    Export the results to text files.
+
+    .PARAMETER Name
+    Name of the file.
+
+    .PARAMETER Data
+    Data that will be exported to a file.
+
+    .PARAMETER FilePath
+    Path in which the file will be created.
+
+    .EXAMPLE
+    Export-Results -Name "Tested $item" -Data $TestedData.$Item
+
+    #>
+    [Cmdletbinding()]
+    param (
+        [string]$Name,
+        $Data,
+        [string]$FilePath = (Join-Path -Path $pwd -ChildPath "BlueTuxedo $Name $(Get-Date -f 'yyyyMMddhhmmss').txt")
+    )
+
+    Out-File -FilePath $FilePath -Encoding utf8 -InputObject $Data
+}

--- a/Public/Invoke-BlueTuxedo.ps1
+++ b/Public/Invoke-BlueTuxedo.ps1
@@ -6,73 +6,97 @@ function Invoke-BlueTuxedo {
         [switch]$ShowSecurityDescriptors = $false,
         [switch]$Demo = $false
     )
+
     if ($Demo) { Clear-Host }
+    Show-BTLogo -Version 'v2024.2-testing'
+
     $Domains = Get-BTTarget -Forest $Forest -InputPath $InputPath
 
-    Show-BTLogo -Version "v2024.2-testing"
-
-    # Get Data
+    #region Get Data
     Write-Host 'Please hold. Collecting DNS data from the following domains:' -ForegroundColor Green
     Write-Host $Domains -ForegroundColor Yellow
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Zones"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Zones" -Verbose
     $ADIZones = Get-BTADIZone -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Conditional Forwarders"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Conditional Forwarders" -Verbose
     $ConditionalForwarders = Get-BTConditionalForwarder -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dangling SPNs"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dangling SPNs" -Verbose
     $DanglingSPNs = Get-BTDanglingSPN -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] DNS Admins Memberships"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] DNS Admins Memberships" -Verbose
     $DnsAdminsMemberships = Get-BTDnsAdminsMembership -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] DNS Update Proxy Memberships"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] DNS Update Proxy Memberships" -Verbose
     $DnsUpdateProxyMemberships = Get-BTDnsUpdateProxyMembership -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts" -Verbose
     $DynamicUpdateServiceAccounts = Get-BTDynamicUpdateServiceAccount -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configuration"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configuration" -Verbose
     $ForwarderConfigurations = Get-BTForwarderConfiguration -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Global Query Blocklists"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Global Query Blocklists" -Verbose
     $GlobalQueryBlockLists = Get-BTGlobalQueryBlockList -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Non ADI Zones"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Name Protection Configuration Lists" -Verbose
+    $NameProtectionConfigurationLists = Get-BTNameProtectionConfiguration -Domains $Domains
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Non ADI Zones" -Verbose
     $NonADIZones = Get-BTNonADIZone -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Query Resolution Policies"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Query Resolution Policies" -Verbose
     $QueryResolutionPolicys = Get-BTQueryResolutionPolicy -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors" -Verbose
     $SecurityDescriptors = Get-BTSecurityDescriptor -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes" -Verbose
     $SocketPoolSizes = Get-BTSocketPoolSize -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Tombstoned Nodes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Tombstoned Nodes" -Verbose
     $TombstonedNodes = Get-BTTombstonedNode -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records" -Verbose
     $WildcardRecords = Get-BTWildcardRecord -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] WPAD Records" -Verbose
     $WPADRecords = Get-BTWPADRecord -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scopes"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scopes" -Verbose
     $ZoneScopes = Get-BTZoneScope -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
+
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers" -Verbose
     $ZoneScopeContainers = Get-BTZoneScopeContainer -ADIZones $ADIZones
+
     Write-Host 'Finished collecting DNS data from the following domains:' -ForegroundColor Green
     Write-Host $Domains -ForegroundColor Yellow
 
     $CollectedData = @{
-        'ADIZones' = $ADIZones
-        'ConditionalForwarders' = $ConditionalForwarders
-        'DanglingSPNs' = $DanglingSPNs
-        'DnsAdminsMemberships' = $DnsAdminsMemberships
-        'DnsUpdateProxyMemberships' = $DnsUpdateProxyMemberships
+        'ADIZones'                     = $ADIZones
+        'ConditionalForwarders'        = $ConditionalForwarders
+        'DanglingSPNs'                 = $DanglingSPNs
+        'DnsAdminsMemberships'         = $DnsAdminsMemberships
+        'DnsUpdateProxyMemberships'    = $DnsUpdateProxyMemberships
         'DynamicUpdateServiceAccounts' = $DynamicUpdateServiceAccounts
-        'ForwarderConfigurations' = $ForwarderConfigurations
-        'GlobalQueryBlockLists' = $GlobalQueryBlockLists
-        'NonADIZones' = $NonADIZones
-        'QueryResolutionPolicys' = $QueryResolutionPolicys
-        'SecurityDescriptors' = $SecurityDescriptors
-        'SocketPoolSizes' = $SocketPoolSizes
-        'TombstonedNodes' = $TombstonedNodes
-        'WildcardRecords' = $WildcardRecords
-        'WPADRecords' = $WPADRecords
-        'ZoneScopes' = $ZoneScopes
-        'ZoneScopeContainers' = $ZoneScopeContainers
+        'ForwarderConfigurations'      = $ForwarderConfigurations
+        'GlobalQueryBlockLists'        = $GlobalQueryBlockLists
+        #'NameProtectionLists'         = $NameProtectionConfigurationLists
+        'NonADIZones'                  = $NonADIZones
+        'QueryResolutionPolicys'       = $QueryResolutionPolicys
+        'SecurityDescriptors'          = $SecurityDescriptors
+        'SocketPoolSizes'              = $SocketPoolSizes
+        'TombstonedNodes'              = $TombstonedNodes
+        'WildcardRecords'              = $WildcardRecords
+        'WPADRecords'                  = $WPADRecords
+        'ZoneScopes'                   = $ZoneScopes
+        'ZoneScopeContainers'          = $ZoneScopeContainers
     }
+    #endregion Get Data
 
     # Display All Collected Data
-    $show = Read-Host "Show all collected DNS data? [Y]/n"
+    $show = Read-Host 'Show all collected DNS data? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
             Show-BTCollectedData -Demo @CollectedData
@@ -88,57 +112,57 @@ function Invoke-BlueTuxedo {
     # Test Data
     if ($Demo) { Clear-Host }
     Write-Host 'Currently testing collected DNS data to identify possible issues...' -ForegroundColor Green
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Legacy Zones"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Legacy Zones"
     $TestedADILegacyZones = Test-BTADILegacyZone -ADIZones $ADIZones
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] ADI Insecure Update Zones"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] ADI Insecure Update Zones"
     $TestedADIInsecureUpdateZones = Test-BTADIInsecureUpdateZone -ADIZones $ADIZones
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dynamic Update Service Accounts"
     $TestedDynamicUpdateServiceAccounts = Test-BTDynamicUpdateServiceAccount -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configurations"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configurations"
     $TestedForwarderConfigurations = Test-BTForwarderConfiguration -ForwarderConfigurations $ForwarderConfigurations
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Global Query Block Lists"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Global Query Block Lists"
     $TestedGlobalQueryBlockLists = Test-BTGlobalQueryBlockList -GlobalQueryBlockLists $GlobalQueryBlockLists
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor ACE"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor ACE"
     $TestedSecurityDescriptorACEs = Test-BTSecurityDescriptorACE -SecurityDescriptors $SecurityDescriptors -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor Owner"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptor Owner"
     $TestedSecurityDescriptorOwners = Test-BTSecurityDescriptorOwner -SecurityDescriptors $SecurityDescriptors -DynamicUpdateServiceAccounts $DynamicUpdateServiceAccounts -Domains $Domains
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
-    $TestedSocketPoolSizes = Test-BTSocketPoolSize -SocketPoolSizes $SocketPoolSizes 
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes"
+    $TestedSocketPoolSizes = Test-BTSocketPoolSize -SocketPoolSizes $SocketPoolSizes
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records"
     $TestedWildcardRecords = Test-BTWildcardRecord -WildcardRecords $WildcardRecords
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] WPAD Records"
     $TestedWPADRecords = Test-BTWPADRecord -WPADRecords $WPADRecords
-    Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
+    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers"
     $TestedZoneScopeContainers = Test-BTZoneScopeContainer -ZoneScopeContainers $ZoneScopeContainers
     Write-Host 'Finished testing collected DNS data to identify possible issues.`n' -ForegroundColor Green
 
     $TestedData = @{
-        'ConditionalForwarders' = $ConditionalForwarders
-        'DanglingSPNs' = $DanglingSPNs
-        'DnsAdminsMemberships' = $DnsAdminsMemberships
-        'DnsUpdateProxyMemberships' = $DnsUpdateProxyMemberships
-        'NonADIZones' = $NonADIZones
-        'QueryResolutionPolicys' = $QueryResolutionPolicys
-        'TombstonedNodes' = $TombstonedNodes
-        'ZoneScopes' = $ZoneScopes
-        'TestedADILegacyZones' = $TestedADILegacyZones
-        'TestedADIInsecureUpdateZones' = $TestedADIInsecureUpdateZones
+        'ConditionalForwarders'              = $ConditionalForwarders
+        'DanglingSPNs'                       = $DanglingSPNs
+        'DnsAdminsMemberships'               = $DnsAdminsMemberships
+        'DnsUpdateProxyMemberships'          = $DnsUpdateProxyMemberships
+        'NonADIZones'                        = $NonADIZones
+        'QueryResolutionPolicys'             = $QueryResolutionPolicys
+        'TombstonedNodes'                    = $TombstonedNodes
+        'ZoneScopes'                         = $ZoneScopes
+        'TestedADILegacyZones'               = $TestedADILegacyZones
+        'TestedADIInsecureUpdateZones'       = $TestedADIInsecureUpdateZones
         'TestedDynamicUpdateServiceAccounts' = $TestedDynamicUpdateServiceAccounts
-        'TestedForwarderConfigurations' = $TestedForwarderConfigurations
-        'TestedGlobalQueryBlockLists' = $TestedGlobalQueryBlockLists
-        'TestedSecurityDescriptorACEs' = $TestedSecurityDescriptorACEs
-        'TestedSecurityDescriptorOwners' = $TestedSecurityDescriptorOwners
-        'TestedSocketPoolSizes' = $TestedSocketPoolSizes
-        'TestedWildcardRecords' = $TestedWildcardRecords
-        'TestedWPADRecords' = $TestedWPADRecords
-        'TestedZoneScopeContainers' = $TestedZoneScopeContainers
+        'TestedForwarderConfigurations'      = $TestedForwarderConfigurations
+        'TestedGlobalQueryBlockLists'        = $TestedGlobalQueryBlockLists
+        'TestedSecurityDescriptorACEs'       = $TestedSecurityDescriptorACEs
+        'TestedSecurityDescriptorOwners'     = $TestedSecurityDescriptorOwners
+        'TestedSocketPoolSizes'              = $TestedSocketPoolSizes
+        'TestedWildcardRecords'              = $TestedWildcardRecords
+        'TestedWPADRecords'                  = $TestedWPADRecords
+        'TestedZoneScopeContainers'          = $TestedZoneScopeContainers
     }
-    
+
     # Display All Tested Data
-    $show = Read-Host "Show possible DNS issues in the environment? [Y]/n"
+    $show = Read-Host 'Show possible DNS issues in the environment? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
-            Show-BTTestedData -Demo  @TestedData
+            Show-BTTestedData -Demo @TestedData
         } elseif ($ShowSecurityDescriptors) {
             Show-BTTestedData -ShowSecurityDescriptors @TestedData
         } elseif ($Demo -and $ShowSecurityDescriptors) {
@@ -149,7 +173,7 @@ function Invoke-BlueTuxedo {
     }
 
     # Display Fixes
-    $show = Read-Host "Show fixes for identified issues? [Y]/n"
+    $show = Read-Host 'Show fixes for identified issues? [Y]/n'
     if (($show -eq 'y') -or ($show -eq '') -or ($null -eq $show) ) {
         if ($Demo) {
             Show-BTFixes -Demo @TestedData

--- a/Public/Invoke-BlueTuxedo.ps1
+++ b/Public/Invoke-BlueTuxedo.ps1
@@ -4,6 +4,7 @@ function Invoke-BlueTuxedo {
         [string]$Forest = (Get-ADForest).Name,
         [string]$InputPath,
         [switch]$ShowSecurityDescriptors = $false,
+        [string[]]$Exclude,
         [switch]$ExportCollectedData,
         [switch]$ExportTestedData,
         [switch]$Demo = $false
@@ -22,7 +23,7 @@ function Invoke-BlueTuxedo {
     $ADIZones = Get-BTADIZone -Domains $Domains
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Conditional Forwarders" -Verbose
-    $ConditionalForwarders = Get-BTConditionalForwarder -Domains $Domains
+    $ConditionalForwarders = Get-BTConditionalForwarder -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Dangling SPNs" -Verbose
     $DanglingSPNs = Get-BTDanglingSPN -Domains $Domains
@@ -37,28 +38,28 @@ function Invoke-BlueTuxedo {
     $DynamicUpdateServiceAccounts = Get-BTDynamicUpdateServiceAccount -Domains $Domains
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Forwarder Configuration" -Verbose
-    $ForwarderConfigurations = Get-BTForwarderConfiguration -Domains $Domains
+    $ForwarderConfigurations = Get-BTForwarderConfiguration -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Global Query Blocklists" -Verbose
-    $GlobalQueryBlockLists = Get-BTGlobalQueryBlockList -Domains $Domains
+    $GlobalQueryBlockLists = Get-BTGlobalQueryBlockList -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Name Protection Configuration Lists" -Verbose
-    $NameProtectionConfigurationLists = Get-BTNameProtectionConfiguration -Domains $Domains
+    #$NameProtectionConfigurationLists = Get-BTNameProtectionConfiguration -Domains $Domains
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Non ADI Zones" -Verbose
-    $NonADIZones = Get-BTNonADIZone -Domains $Domains
+    $NonADIZones = Get-BTNonADIZone -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Query Resolution Policies" -Verbose
-    $QueryResolutionPolicys = Get-BTQueryResolutionPolicy -Domains $Domains
+    $QueryResolutionPolicys = Get-BTQueryResolutionPolicy -Domains $Domains -Exclude $Exclude
 
-    Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors" -Verbose
-    $SecurityDescriptors = Get-BTSecurityDescriptor -Domains $Domains
+    #Write-Verbose "[$(Get-Date -format 'yyyy-MM-dd hh:mm:ss')] Security Descriptors" -Verbose
+    #$SecurityDescriptors = Get-BTSecurityDescriptor -Domains $Domains
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Socket Pool Sizes" -Verbose
-    $SocketPoolSizes = Get-BTSocketPoolSize -Domains $Domains
+    $SocketPoolSizes = Get-BTSocketPoolSize -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Tombstoned Nodes" -Verbose
-    $TombstonedNodes = Get-BTTombstonedNode -Domains $Domains
+    $TombstonedNodes = Get-BTTombstonedNode -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Wildcard Records" -Verbose
     $WildcardRecords = Get-BTWildcardRecord -Domains $Domains
@@ -67,7 +68,7 @@ function Invoke-BlueTuxedo {
     $WPADRecords = Get-BTWPADRecord -Domains $Domains
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scopes" -Verbose
-    $ZoneScopes = Get-BTZoneScope -Domains $Domains
+    $ZoneScopes = Get-BTZoneScope -Domains $Domains -Exclude $Exclude
 
     Write-Verbose "[$(Get-Date -Format 'yyyy-MM-dd hh:mm:ss')] Zone Scope Containers" -Verbose
     $ZoneScopeContainers = Get-BTZoneScopeContainer -ADIZones $ADIZones


### PR DESCRIPTION
This PR should be reviewed _after_ 'https://github.com/TrimarcJake/BlueTuxedo/pull/31' because it builds upon those additions. The main premise of this is to enable the exclusion of a DNS Server. I added this while I was testing an environment that had an offline DNS server and it was messing up my results.

# Updates
- Added the Get-DNSServer function with the Exclude parameter
- Added the exclude parameter to all functions that use the $DNSServers object
- Added the exclude parameter to Invoke-BlueTuxedo
- Added pre/post merge scriptblocks to enable the -Exclude parameter to work on the single merged function

# Fixes
- Added a missing reference to Get-NameProtectionConfiguration while gathering data
- Minor typo and spacing fixes